### PR TITLE
ImageLineHelper palette2rgb fix when forcing alpha

### DIFF
--- a/src/main/java/ar/com/hjg/pngj/ImageLineHelper.java
+++ b/src/main/java/ar/com/hjg/pngj/ImageLineHelper.java
@@ -305,7 +305,7 @@ public class ImageLineHelper {
 
 	private static int[] palette2rgb(IImageLine line, PngChunkPLTE pal, PngChunkTRNS trns, int[] buf,
 			boolean alphaForced) {
-		boolean isalpha = trns != null;
+		boolean isalpha = trns != null || alphaForced;
 		int channels = isalpha ? 4 : 3;
 		ImageLineInt linei = (ImageLineInt) (line instanceof ImageLineInt ? line : null);
 		ImageLineByte lineb = (ImageLineByte) (line instanceof ImageLineByte ? line : null);


### PR DESCRIPTION
Previously the alphaForced parameter of palette2rgb method in ImageLineHelper was not used and therefore you couldn't force the alpha